### PR TITLE
fix a mistake

### DIFF
--- a/config/functions/build
+++ b/config/functions/build
@@ -5,7 +5,7 @@
 
 ## Build U-Boot
 NR_CPUS=$(grep -c processor /proc/cpuinfo)
-if [ ${NR_CPUS} -le 8]; then
+if [ ${NR_CPUS} -le 8 ]; then
     NR_JOBS=${NR_CPUS}
 else
     NR_JOBS=8


### PR DESCRIPTION
config/functions/build: 第 8 行:[: 缺少 `]'

Signed-off-by: ykdl <832666+zhangn1985@users.noreply.github.com>