### PR TITLE
use python to run .pyc

### DIFF
--- a/packages/u-boot-mainline/package.mk
+++ b/packages/u-boot-mainline/package.mk
@@ -26,7 +26,7 @@ post_make_target() {
 		cp -r $PKGS_DIR/$PKG_NAME/fip/$KHADAS_BOARD $BUILD/$PKG_NAME-$PKG_VERSION/fip
 		cp u-boot.bin fip/bl33.bin
 		fip/blx_fix.sh fip/bl30.bin fip/zero_tmp fip/bl30_zero.bin fip/bl301.bin fip/bl301_zero.bin fip/bl30_new.bin bl30
-		fip/acs_tool.pyc fip/bl2.bin fip/bl2_acs.bin fip/acs.bin 0
+		python fip/acs_tool.pyc fip/bl2.bin fip/bl2_acs.bin fip/acs.bin 0
 		fip/blx_fix.sh fip/bl2_acs.bin fip/zero_tmp fip/bl2_zero.bin fip/bl21.bin fip/bl21_zero.bin fip/bl2_new.bin bl2
 		fip/aml_encrypt_gxl --bl3enc --input fip/bl30_new.bin
 		fip/aml_encrypt_gxl --bl3enc --input fip/bl31.img


### PR DESCRIPTION
due to below error in docker:
fip/acs_tool.pyc: line 1: $'\003\363\r': command not found
fip/acs_tool.pyc: line 2: $'\373]\372Uc\a@s*\002dd\001lZdd\001l\001Z\001dd\001l\002Z\001dd\001l\003Z\003dd\002l\004Tdd\001l\005Z\005dd\001l\006Z\006dd\001l\aZ\add\001l\bZ\bd\003Z': command not found
: No such file or directorye
fip/acs_tool.pyc: line 4: d
d                          e
 : No such file or directory
fip/acs_tool.pyc: line 11: unexpected EOF while looking for matching ``'
fip/acs_tool.pyc: line 41: syntax error: unexpected end of file
Makefile:7: recipe for target 'all' failed
make: *** [all] Error 2

this requires to use python to run .pyc

Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>