### PR TITLE
Added command line parameter for mode/level changes in fan.sh

### DIFF
--- a/archives/filesystem/special/VIM-COMMON/usr/local/bin/fan.sh
+++ b/archives/filesystem/special/VIM-COMMON/usr/local/bin/fan.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+FAN_INPUT="${1:-"auto"}"
+
 FAN_ENABLE_NODE="/sys/class/fan/enable"
 FAN_MODE_NODE="/sys/class/fan/mode"
 FAN_LEVEL_NODE="/sys/class/fan/level"
@@ -18,35 +20,58 @@ LEVEL_HIGH=3
 # high
 mode="auto"
 
-for m in $(cat /proc/cmdline); do
-	case ${m} in
-		fan=*) mode=${m#*=} ;;
+if [ "$FAN_INPUT" = "mode" ]; then
+	mode=$FAN_INPUT
+
+	FAN_MODE=$(cat $FAN_MODE_NODE | awk '{print $3}')
+	FAN_LEVEL=$(cat $FAN_LEVEL_NODE | awk '{print $3}')
+	
+	if [ $FAN_MODE -eq 0 ]; then FAN_MODE=manual; else FAN_MODE=auto; fi
+	
+	case $FAN_LEVEL in
+		0) FAN_LEVEL=off ;;
+		1) FAN_LEVEL=low ;;
+		2) FAN_LEVEL=mid ;;
+		3) FAN_LEVEL=high ;;
 	esac
-done
+elif [ "$FAN_INPUT" != "mode" ]; then
+	mode=$FAN_INPUT
+else {	
+	for m in $(cat /proc/cmdline); do
+		case ${m} in
+			fan=*) mode=${m#*=} ;;
+		esac
+	done
+	}
+fi
 
 case $mode in
 	off)
 		echo 0 > $FAN_ENABLE_NODE
 		;;
 	low)
-		echo $LEVEL_LOW > $FAN_LEVEL_NODE
-		echo $MANUAL_MODE > $FAN_MODE_NODE
 		echo 1 > $FAN_ENABLE_NODE
+		echo $MANUAL_MODE > $FAN_MODE_NODE
+		echo $LEVEL_LOW > $FAN_LEVEL_NODE
 		;;
 	mid)
-		echo $LEVEL_MID > $FAN_LEVEL_NODE
-		echo $MANUAL_MODE > $FAN_MODE_NODE
 		echo 1 > $FAN_ENABLE_NODE
+		echo $MANUAL_MODE > $FAN_MODE_NODE
+		echo $LEVEL_MID > $FAN_LEVEL_NODE
 		;;
 	high)
-		echo $LEVEL_HIGH > $FAN_LEVEL_NODE
-		echo $MANUAL_MODE > $FAN_MODE_NODE
 		echo 1 > $FAN_ENABLE_NODE
+		echo $MANUAL_MODE > $FAN_MODE_NODE
+		echo $LEVEL_HIGH > $FAN_LEVEL_NODE
 		;;
-	auto)
+	auto|on)
 		echo $AUTO_MODE > $FAN_MODE_NODE
 		echo 1 > $FAN_ENABLE_NODE
 		;;
+	mode)
+		echo "Fan mode: $FAN_MODE"
+		echo "Fan level: $FAN_LEVEL"
+		;;	
 esac
 
 exit 0


### PR DESCRIPTION
1) Corrected a bug that prevents to set the correct level after off
Enable must be the first command to be executed

2) Added a mode/level CLI parameter that allows someone to change the mode/level or use some policies/rules to change mode/level automatically

3) Messages are sent to syslog using logger

4) Kernel mode is not affected by this changes, because the parameter defaults to `boot` using the default behavior

```bash
khadas@Khadas:~$ sudo fan.sh usage
Error: Fan mode/level is unknown!

Usage: /usr/local/bin/fan.sh [on|low|mid|high|auto|off] - Set fan mode/level
       /usr/local/bin/fan.sh [mode] - Query fan mode/level

Examp: /usr/local/bin/fan.sh auto
```

```bash
khadas@Khadas:~$ sudo fan.sh mode
Fan mode: auto
Fan level: off
```