### PR TITLE
linux-mainline-patches

### DIFF
--- a/packages/linux-mainline/patches/5.7-rc7/0101-amlogic_vim_spifc_fix.patch
+++ b/packages/linux-mainline/patches/5.7-rc7/0101-amlogic_vim_spifc_fix.patch
@@ -1,0 +1,54 @@
+From 00f40ea6def8bf0d698ed870a9efc6dad373ee3a Mon Sep 17 00:00:00 2001
+From: hyphop <art@khadas.com>
+Date: Mon, 1 Jun 2020 14:37:30 +0900
+Subject: [PATCH] amlogic_vim_spifc_fix
+
+change spi flash freq to 104Mhz for VIM2 
+change name to w25q128
+
+---
+ .../boot/dts/amlogic/meson-gxm-khadas-vim2.dts     | 14 +++++++-------
+ arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi |  2 +-
+ 2 files changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+index 110f71bf5..0686104c8 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+@@ -343,13 +343,13 @@
+ 	pinctrl-0 = <&nor_pins>;
+ 	pinctrl-names = "default";
+ 
+-	w25q32: spi-flash@0 {
+-		#address-cells = <1>;
+-		#size-cells = <1>;
+-		compatible = "winbond,w25q16", "jedec,spi-nor";
+-		reg = <0>;
+-		spi-max-frequency = <3000000>;
+-	};
++    w25q128: spi-flash@0 {
++	#address-cells = <1>;
++	#size-cells = <1>;
++	compatible = "winbond,w25q128fw", "jedec,spi-nor";
++	reg = <0>;
++	spi-max-frequency = <104000000>;
++    };
+ };
+ 
+ /* This one is connected to the Bluetooth module */
+diff --git a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
+index 3fe4c6dd0..773816baf 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
+@@ -360,7 +360,7 @@
+ 	pinctrl-0 = <&nor_pins>;
+ 	pinctrl-names = "default";
+ 
+-	w25q32: spi-flash@0 {
++	w25q128: spi-flash@0 {
+ 		#address-cells = <1>;
+ 		#size-cells = <1>;
+ 		compatible = "winbond,w25q128fw", "jedec,spi-nor";
+-- 
+2.17.1
+

--- a/packages/linux-mainline/patches/5.7-rc7/0102-amlogic_vim2_vim3_led_fix.patch
+++ b/packages/linux-mainline/patches/5.7-rc7/0102-amlogic_vim2_vim3_led_fix.patch
@@ -1,0 +1,71 @@
+From e3c65a90327bf33a5cfa8bd6c29c822c6046e777 Mon Sep 17 00:00:00 2001
+From: hyphop <art@khadas.com>
+Date: Mon, 1 Jun 2020 15:00:42 +0900
+Subject: [PATCH] amlogic_vim2_vim3_led_fix
+
+add missed leds to VIM2
+change VIM3 to GPIO_ACTIVE_HIGH + fix names and aliases
+
+---
+ .../dts/amlogic/meson-gxm-khadas-vim2.dts     |   14 +
+ .../boot/dts/amlogic/meson-khadas-vim3.dtsi   |   12 +-
+ 2 files changed
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+index 0686104c8..e7376fd05 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+@@ -146,6 +146,18 @@
+ 		clock-frequency = <32768>;
+ 		pwms = <&pwm_ef 0 30518 0>; /* PWM_E at 32.768KHz */
+ 	};
++
++	leds {
++		compatible = "gpio-leds";
++		status = "okay";
++		led_white: led-white {
++			label = "vim:white";
++			gpios = <&gpio_ao GPIOAO_9 GPIO_ACTIVE_HIGH>;
++			linux,default-trigger = "heartbeat";
++	};
++
++    };
++
+ };
+ 
+ &cec_AO {
+@@ -390,3 +402,5 @@
+ &usb0 {
+ 	status = "okay";
+ };
++
++
+diff --git a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
+index 773816baf..d416d7def 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
++++ b/arch/arm64/boot/dts/amlogic/meson-khadas-vim3.dtsi
+@@ -39,15 +39,15 @@
+ 	leds {
+ 		compatible = "gpio-leds";
+ 
+-		led-white {
+-			label = "vim3:white:sys";
+-			gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_LOW>;
++		led_white: led-white {
++			label = "vim:white";
++			gpios = <&gpio_ao GPIOAO_4 GPIO_ACTIVE_HIGH>;
+ 			linux,default-trigger = "heartbeat";
+ 		};
+ 
+-		led-red {
+-			label = "vim3:red";
+-			gpios = <&gpio_expander 5 GPIO_ACTIVE_LOW>;
++		led_red: led-red {
++			label = "vim:red";
++			gpios = <&gpio_expander 5 GPIO_ACTIVE_HIGH>;
+ 		};
+ 	};
+ 
+-- 
+2.17.1
+

--- a/packages/linux-mainline/patches/5.7-rc7/0103-rockchip_khadas_edge_add_missed_spiflash.patch
+++ b/packages/linux-mainline/patches/5.7-rc7/0103-rockchip_khadas_edge_add_missed_spiflash.patch
@@ -1,0 +1,35 @@
+From d5d6e0a377f7e32e2d3d6b26335427dd21bd2fd2 Mon Sep 17 00:00:00 2001
+From: hyphop <art@khadas.com>
+Date: Mon, 1 Jun 2020 15:06:01 +0900
+Subject: [PATCH] rockchip_khadas_edge_add_missed_spiflash
+
+add missed spiflash to Khadas Edge 
+---
+ .../boot/dts/rockchip/rk3399-khadas-edge.dtsi      | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+index e87a04477..25927a74b 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+@@ -805,3 +805,17 @@
+ &vopl_mmu {
+ 	status = "okay";
+ };
++
++
++&spi1 {
++    max-freq = <104000000>;
++    status = "okay";
++
++    spiflash: flash@0 {
++    u-boot,dm-pre-reloc;
++    compatible = "winbond,w25q128fw", "jedec,spi-nor";
++    reg = <0>;
++    spi-max-frequency = <104000000>;
++    };
++};
++
+-- 
+2.17.1
+

--- a/packages/linux-mainline/patches/5.7-rc7/0104-rockchip_khadas_edge_add_ir_recv.patch
+++ b/packages/linux-mainline/patches/5.7-rc7/0104-rockchip_khadas_edge_add_ir_recv.patch
@@ -1,0 +1,50 @@
+From 90575bac638491e244ded5710965b8338fdddb3e Mon Sep 17 00:00:00 2001
+From: hyphop <art@khadas.com>
+Date: Mon, 1 Jun 2020 15:08:18 +0900
+Subject: [PATCH] rockchip_khadas_edge_add_ir_recv
+
+add missed ir receivier to Khadas Edge
+
+arm64: dts: rockchip: ir-recevier and ir_rx pinctl
+
+---
+ .../boot/dts/rockchip/rk3399-khadas-edge.dtsi    | 16 ++++++++++++++++
+ 1 file changed, 16 insertions(+)
+
+diff --git a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+index 25927a74b..f4d69bfd4 100644
+--- a/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
++++ b/arch/arm64/boot/dts/rockchip/rk3399-khadas-edge.dtsi
+@@ -109,6 +109,14 @@
+ 		vin-supply = <&vsys>;
+ 	};
+ 
++	ir-receiver {
++		compatible = "gpio-ir-receiver";
++		gpios = <&gpio1 RK_PB6 GPIO_ACTIVE_LOW>;
++		pinctrl-names = "default";
++		pinctrl-0 = <&ir_rx>;
++		linux,rc-map-name = "rc-khadas";
++	};
++
+ 	adc-keys {
+ 		compatible = "adc-keys";
+ 		io-channels = <&saradc 1>;
+@@ -682,6 +690,14 @@
+ 	status = "okay";
+ };
+ 
++&pinctrl {
++    ir {
++	ir_rx: ir-rx {
++	    rockchip,pins = <1 RK_PB6 RK_FUNC_GPIO &pcfg_pull_none>;
++	};
++    };
++};
++
+ &sdhci {
+ 	bus-width = <8>;
+ 	mmc-hs400-1_8v;
+-- 
+2.17.1
+


### PR DESCRIPTION
 4 files changed, 210 insertions(+)
 create mode 100644 packages/linux-mainline/patches/5.7-rc7/0101-amlogic_vim_spifc_fix.patch
 create mode 100644 packages/linux-mainline/patches/5.7-rc7/0102-amlogic_vim2_vim3_led_fix.patch
 create mode 100644 packages/linux-mainline/patches/5.7-rc7/0103-rockchip_khadas_edge_add_missed_spiflash.patch
 create mode 100644 packages/linux-mainline/patches/5.7-rc7/0104-rockchip_khadas_edge_add_ir_recv.patch
