### PR TITLE
linux-mainline-patches-2

### DIFF
--- a/packages/linux-mainline/patches/5.7-rc7/0105-fix-broken-ethernet-interface-up-down.patch
+++ b/packages/linux-mainline/patches/5.7-rc7/0105-fix-broken-ethernet-interface-up-down.patch
@@ -1,0 +1,34 @@
+From 08d5aef0fa38d61ea142c217ce5aaeb6b18da068 Mon Sep 17 00:00:00 2001
+From: hyphop <email2tema@gmail.com>
+Date: Tue, 12 Nov 2019 10:23:47 +0300
+Subject: [PATCH] fix broken ethernet interface up/down
+
+---
+ arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts | 7 ++++++-
+ 1 file changed, 6 insertions(+), 1 deletion(-)
+
+diff --git a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+index fe3d7d4..0416957 100644
+--- a/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
++++ b/arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts
+@@ -289,11 +289,16 @@
+ 
+ 		reset-assert-us = <10000>;
+ 		reset-deassert-us = <30000>;
+-		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
++// no need it
++// broken ifconfig eth0 down && ifconfig eth0 up # never up again with next line
++//		reset-gpios = <&gpio GPIOZ_14 GPIO_ACTIVE_LOW>;
++		max-speed = <1000>;
+ 
+ 		interrupt-parent = <&gpio_intc>;
+ 		/* MAC_INTR on GPIOZ_15 */
+ 		interrupts = <25 IRQ_TYPE_LEVEL_LOW>;
++
++
+ 	};
+ };
+ 
+-- 
+2.14.1
+


### PR DESCRIPTION
fix broken ethernet interface up/down

 arch/arm64/boot/dts/amlogic/meson-gxm-khadas-vim2.dts | 7 ++++++-
