### PR TITLE
VIM3 default cpu governor

### DIFF
--- a/config/boards/VIM3.conf
+++ b/config/boards/VIM3.conf
@@ -39,9 +39,9 @@ esac
 ####
 GPU_MODEL="arm-mali-bifrost-g52" # A311D Mali-G52MP4
 
-CPUMIN=500000
-CPUMAX=2400000
-GOVERNOR=performance
+CPUMIN=100000
+CPUMAX=2200000
+GOVERNOR=conservative
 
 BOOT_ENV_FILE_EXT="VIM3_env_ext.txt"
 


### PR DESCRIPTION
VIM3 was overheating after idling (!) for a few hours with the fan off (triggered by temperature). Changed default governor to 'conservative' with range of 100-2200 MHz.
(cpufreq limits were 100.0 MHz - 1.80 GHz for one set of cores and 100.0 MHz - 2.21 GHz for another). 
I didn't observe any performance changes, since it clocked at 2.2 GHz under load anyway.