### PR TITLE
Rewrite check for built-in binfmt_misc

### DIFF
--- a/config/functions/common-functions
+++ b/config/functions/common-functions
@@ -150,23 +150,22 @@ prepare_host() {
 	fi
 
 	# enable arm binary format so that the cross-architecture chroot environment will work
-	if [ ! -f /proc/sys/fs/binfmt_misc/status ]; then
+	mountpoint -q /proc/sys/fs/binfmt_misc/ || sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc || {
 		if ! grep -q binfmt_misc <(lsmod); then
 			info_msg "Module 'binfmt_misc' not installed, try to install it!"
-			warning_msg "Requires root privileges, please enter your passowrd!"
+			warning_msg "Requires root privileges, please enter your password!"
 			sudo modprobe -q binfmt_misc || {
 				# FIXME 'binfmt_misc' should be installed on host PC manually
 				# https://github.com/khadas/fenix/issues/35#issuecomment-492326880
 				if systemd-detect-virt -q -c; then
-				error_msg "You are built in container: $(systemd-detect-virt), but the module 'binfmt_misc' is not installed, please exit the container to execute 'sudo modprobe binfmt_misc' on your host PC and try again!"
+                    error_msg "You are built in container: $(systemd-detect-virt), but the module 'binfmt_misc' is not installed, please exit the container to execute 'sudo modprobe binfmt_misc' on your host PC and try again!"
 				fi
 
 				exit -1
 			}
 		fi
-	fi
+    }
 
-	mountpoint -q /proc/sys/fs/binfmt_misc/ || sudo mount binfmt_misc -t binfmt_misc /proc/sys/fs/binfmt_misc
 	test -e /proc/sys/fs/binfmt_misc/qemu-arm || sudo update-binfmts --enable qemu-arm
 	test -e /proc/sys/fs/binfmt_misc/qemu-aarch64 || sudo update-binfmts --enable qemu-aarch64
 }


### PR DESCRIPTION
This is in reference to issue #106. If binfmt_misc is built into the host kernel, the module checks will fail, even though binfmt_misc can be used. But it still might need to be mounted first. So the checks here work like this:
 - first check if there is a /proc mountpoint
 - if not, try to mount it (which will work if binfmt_misc is built in)
 - if it doesn't work, do the module checks (line 153 to 167)
This works on my machine with binfmt_misc built-in. If binfmt_misc is a module on the host system, the mount command will fail, and old code will be run (line 153 to 167) which should load the module etc. like before.