### PR TITLE
Resolve /etc/localtime as fallback for missing /etc/timezone

### DIFF
--- a/config/config
+++ b/config/config
@@ -158,10 +158,18 @@ NAMESERVER="1.0.0.1" # default is cloudflare alternate
 ROOTFS_TYPE="ext4"
 BOOTFS_TYPE="fat"
 
-if [ "$BUILD_TYPE" == "release" ]; then
-	TZDATA="Etc/UTC" # Use 'Etc/UTC' when release images.
-else
-	TZDATA=`cat /etc/timezone` # Timezone for target is taken from host or defined here.
+TZDATA=
+# Timezone for target is taken from host, but not for release images.
+if [ "$BUILD_TYPE" != release ]; then
+	if [ -f /etc/timezone ]; then
+		TZDATA=`cat /etc/timezone`
+	elif [ -L /etc/localtime ]; then
+		TZDATA=$(readlink /etc/localtime | sed -ne 's|^.*/zoneinfo/||p')
+	fi
+fi
+if [ -z "${TZDATA}" ]; then
+	# Default to 'Etc/UTC'.
+	TZDATA=Etc/UTC
 fi
 
 # Non-interactive mode auto detect


### PR DESCRIPTION
I’ve been working on getting Fenix to run on Gentoo. /etc/timezone is a Debian-ism that Gentoo does not use, and I’d imagine other distros don’t have that either. On the other hand, /etc/localtime is used by the C library, so it’s much more common.