### PR TITLE
lsb_release is not installed by default; use /etc/os-release instead

### DIFF
--- a/config/functions/common-functions
+++ b/config/functions/common-functions
@@ -74,7 +74,7 @@ prepare_host() {
 		return -1
 	fi
 
-	local build_host=$(lsb_release -sc)
+	local build_host=$(sed -ne 's/^VERSION_CODENAME=//p' </etc/os-release)
 	info_msg "Build host: $build_host target: $DISTRIB_RELEASE"
 
 	[ "$NO_HOST_CHECK" ] || {


### PR DESCRIPTION
Running Fenix on a fresh, clean, minimal Debian install, results in an error because lsb_release is not installed by default. Also not all distros have lsb_release. However /etc/os-release is more standard, and available by default.