### PR TITLE
fix 2 build issues

### DIFF
--- a/packages/linux-mainline/patches/5.17/0081-export-symbol-max_pcie_mrrs.patch
+++ b/packages/linux-mainline/patches/5.17/0081-export-symbol-max_pcie_mrrs.patch
@@ -1,0 +1,24 @@
+From 9418458f16e46bd19c3e0516f21aa293c6bae376 Mon Sep 17 00:00:00 2001
+From: Zhang Ning <1408979+zhangn1985@user.noreply.gitee.com>
+Date: Sun, 1 May 2022 10:19:03 +0800
+Subject: [PATCH] export symbol max_pcie_mrrs
+
+---
+ drivers/pci/pci.c | 1 +
+ 1 file changed, 1 insertion(+)
+
+diff --git a/drivers/pci/pci.c b/drivers/pci/pci.c
+index 823827805752..97b6e1dec726 100644
+--- a/drivers/pci/pci.c
++++ b/drivers/pci/pci.c
+@@ -120,6 +120,7 @@ enum pcie_bus_config_types pcie_bus_config = PCIE_BUS_DEFAULT;
+ 
+ /* PCIe Max Read Request Size, default 4096 no limit */
+ u16 max_pcie_mrrs = 4096;
++EXPORT_SYMBOL(max_pcie_mrrs);
+ 
+ /*
+  * The default CLS is used if arch didn't set CLS explicitly and not
+-- 
+2.35.1
+

--- a/packages/linux-mainline/patches/5.17/0082-fix-amlogic-npu-build-issue.patch
+++ b/packages/linux-mainline/patches/5.17/0082-fix-amlogic-npu-build-issue.patch
@@ -1,0 +1,29 @@
+From a287c4bb3e39a4108d138515a91c4080a4b8a2e1 Mon Sep 17 00:00:00 2001
+From: Zhang Ning <1408979+zhangn1985@user.noreply.gitee.com>
+Date: Sun, 1 May 2022 10:13:40 +0800
+Subject: [PATCH] fix amlogic npu build issue
+
+when build kernel out of source tree, the include dir is incorrect.
+this makes build fail.
+
+add $(VPATH) to npu Kbuild AQROOT to fix the issue
+---
+ drivers/staging/npu/Kbuild | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/staging/npu/Kbuild b/drivers/staging/npu/Kbuild
+index 87d451c0c89b..116efa4c29aa 100755
+--- a/drivers/staging/npu/Kbuild
++++ b/drivers/staging/npu/Kbuild
+@@ -57,7 +57,7 @@
+ # Linux build file for kernel HAL driver.
+ #
+ 
+-AQROOT = drivers/staging/npu
++AQROOT = $(VPATH)/drivers/staging/npu
+ 
+ include $(AQROOT)/config
+ 
+-- 
+2.35.1
+


### PR DESCRIPTION
Signed-off-by: Zhang Ning <832666+zhangn1985@users.noreply.github.com>

1, NPU驱动在out of source tree编译模式下，编译失败。
2, meson-pcie 驱动编译成模块的情况下，max_pcie_mrrs 找不到。