### PR TITLE
Remove dependency on Linux kernel when building uboot-deb or uboot-image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,10 +35,10 @@ uboot-clean: _env_is_setup
 debs: uboot kernel
 	@./scripts/build.sh debs
 
-uboot-deb: uboot kernel
+uboot-deb: uboot
 	@./scripts/build.sh uboot-deb
 
-uboot-image: uboot kernel
+uboot-image: uboot
 	@./scripts/build.sh uboot-image
 
 kernel-deb: kernel


### PR DESCRIPTION
There is no need to build whole linux kernel when user only wants to build uboot-deb or uboot-image. Hence removing this dependency.