### PR TITLE
Minor fixes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,9 @@ image: _env_is_setup
 kernel: _env_is_setup
 	@./scripts/build.sh linux
 
+kernel-dtbs: _env_is_setup
+	@BUILD_LINUX_DTBS_ONLY=yes ./scripts/build.sh linux
+
 kernel-clean: _env_is_setup
 	@./scripts/build.sh linux-clean
 
@@ -35,10 +38,10 @@ uboot-clean: _env_is_setup
 debs: uboot kernel
 	@./scripts/build.sh debs
 
-uboot-deb: uboot kernel
+uboot-deb: uboot kernel-dtbs
 	@./scripts/build.sh uboot-deb
 
-uboot-image: uboot kernel
+uboot-image: uboot kernel-dtbs
 	@./scripts/build.sh uboot-image
 
 kernel-deb: kernel

--- a/config/boards/VIM4.conf
+++ b/config/boards/VIM4.conf
@@ -5,8 +5,8 @@
 SUPPORTED_UBOOT=("2019.01")
 SUPPORTED_UBOOT_DESC=("U-boot 2019.01")
 declare -A SUPPORTED_LINUX SUPPORTED_LINUX_DESC
-SUPPORTED_LINUX["2019.01"]="5.15 mainline"
-SUPPORTED_LINUX_DESC["2019.01"]="'Linux 5.15' 'Linux Mainline'"
+SUPPORTED_LINUX["2019.01"]="5.15"
+SUPPORTED_LINUX_DESC["2019.01"]="'Linux 5.15'"
 
 DISTRIBUTION_ARRAY=("Ubuntu" "Debian")
 DISTRIBUTION_ARRAY_DESC=("Ubuntu" "Debian")
@@ -52,15 +52,14 @@ UBOOT_IMAGE_FILES="u-boot.bin.signed u-boot.bin.sd.bin.signed u-boot.bin.spi.bin
 
 case "$LINUX" in
 	mainline)
-		LINUX_DTB="$LINUX_DIR/arch/arm64/boot/dts/amlogic/amlogic-t7-a311d2-khadas-vim4.dtb"
-		LINUX_GIT_BRANCH="khadas-linux-6.4.y"
-		LINUX_DEFCONFIG="${LINUX_DEFCONFIG:-kvims_defconfig}"
+		LINUX_DTB=""
+		LINUX_GIT_BRANCH="master"
+		LINUX_DEFCONFIG="${LINUX_DEFCONFIG:-defconfig}"
 		SERIALCON="ttyAML0"
 		GPU_VER=""
 		GPU_PLATFORM=""
 		GPU_TYPE=""
 		MODESETTING_CONF=""
-		EXTLINUX_CONF="VIM4_extlinux_mainline.conf"
 		;;
 	5.15)
 		LINUX_DTB="$LINUX_COMMON_DRIVERS_DIR/arch/arm64/boot/dts/amlogic/kvim4n.dtb"
@@ -77,7 +76,6 @@ case "$LINUX" in
 		fi
 		GPU_TYPE="gondul"
 		MODESETTING_CONF=""
-		EXTLINUX_CONF="VIM4_extlinux.conf"
 		;;
 esac
 
@@ -96,6 +94,7 @@ BOOT_SCRIPT_VENDOR=""
 BOOT_INI=""
 BOOT_ENV_FILE_NEW="VIM4_uEnv.txt"
 BOOT_ENV_FILE_EXT=""
+EXTLINUX_CONF="VIM4_extlinux.conf"
 
 #### Packing image
 IMAGE_PACKAGE_CONF=package_t7.conf

--- a/config/bootscripts/extlinux/VIM4_extlinux_mainline.conf
+++ b/config/bootscripts/extlinux/VIM4_extlinux_mainline.conf
@@ -1,9 +1,0 @@
-menu background /splash.bmp
-LABEL Default
-  LINUX /Image
-  INITRD /initrd.img
-  FDT /dtb/amlogic/amlogic-t7-a311d2-khadas-vim4.dtb
-  APPEND ${rootdev} rw console=ttyAML0,921600 no_console_suspend earlycon=aml-uart,0xfe078000 audit=0
-
-timeout 5
-default Default

--- a/config/functions/build
+++ b/config/functions/build
@@ -194,7 +194,11 @@ build_linux() {
 	echo "${KERNEL_COMPILER} $KERNEL_COMPILER_PATH"
 	export PATH=$KERNEL_COMPILER_PATH:$PATH
 	make ARCH=arm64 CROSS_COMPILE="${KERNEL_COMPILER}" $LINUX_DEFCONFIG
-	make -j${NR_JOBS} ARCH=arm64 CROSS_COMPILE="${CCACHE} ${KERNEL_COMPILER}" Image dtbs  modules $EXTRA_MAKE_ARGS
+	if [ "${BUILD_LINUX_DTBS_ONLY:-no}" == "yes" ]; then
+		make -j${NR_JOBS} ARCH=arm64 CROSS_COMPILE="${CCACHE} ${KERNEL_COMPILER}" dtbs $EXTRA_MAKE_ARGS
+	else
+		make -j${NR_JOBS} ARCH=arm64 CROSS_COMPILE="${CCACHE} ${KERNEL_COMPILER}" Image dtbs  modules $EXTRA_MAKE_ARGS
+	fi
 }
 
 ## Build linux debs

--- a/env/setenv.sh
+++ b/env/setenv.sh
@@ -326,6 +326,10 @@ file '$ROOT/config/boards/${KHADAS_BOARD}.conf'? Please add it!"
 
     echo_
 
+    # no need ask if only one choose ;-)
+    [ "$UBOOT_VERSION_ARRAY_LEN" = 1 ] && echo_ -n "only one choose " && \
+		UBOOT="${SUPPORTED_UBOOT[0]}" && return 0
+
     local DEFAULT_NUM
     DEFAULT_NUM=1
     export UBOOT=


### PR DESCRIPTION
Bunch of minor fixes

- Added new kernel-dtbs target to speed up execution of uboot-deb and uboot-image targets. As this only build kernel dtbs instead of the complete kernel, it saves a lot of time when doing uboot specific development and testing
- Reverted mainline kernel support for vim4. The mainline 6.4 kernel doesn't have vim4 dts or defconfig and does not build. Hence removing the same
- Also we ask to select u-boot version even when only single uboot version is available. So I have made the behavior consistent with Linux kernel selection where we automatically select the only available option