### PR TITLE
update build host dependencies

### DIFF
--- a/config/functions/common-functions
+++ b/config/functions/common-functions
@@ -79,10 +79,15 @@ prepare_host() {
 
 	[ "$NO_HOST_CHECK" ] || {
 		case $build_host in
-		noble)
-		## looks like can build all prev system
+		jammy)
+		## looks like can build all system
 		;;
-		hirsute|bullseye|jammy)
+		noble)
+			case $DISTRIB_RELEASE in
+				jammy) broken_ ;;
+			esac
+		;;
+		hirsute|bullseye|bookworm)
 			case $DISTRIB_RELEASE in
 				noble) broken_ ;;
 			esac


### PR DESCRIPTION
Seems like we can build everything on Jammy. When building jammy on noble, qemu segfaults. Also added bookworm to the list as it was missing