### PR TITLE
dracut-install: fix performance regression

### DIFF
--- a/config/boards/VIM1S.conf
+++ b/config/boards/VIM1S.conf
@@ -229,6 +229,14 @@ tweaks_platform() {
 ## Build deb packages for platform
 build_deb_packages_platform() {
 
+	if  [ "$DISTRIB_RELEASE" == "noble" ] ; then
+		info_msg "Building dracut_install package..."
+		# FIXME
+		# remove build stamp to force build for other arch
+		rm -rf $BUILD/.stamps/dracut_install
+		build_package "dracut_install:target"
+	fi
+
 	if [ "$DISTRIB_TYPE" == "minimal" ]; then
 		warning_msg "Ignore build platform packages for minimal image."
 		return 0
@@ -301,6 +309,11 @@ build_deb_packages_platform() {
 
 ## Install deb packages for platform
 install_deb_packages_platform() {
+
+	if [ "$DISTRIB_RELEASE" == "noble" ]; then
+		info_msg "Installing dracut_install package ..."
+		install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/$DISTRIBUTION-$DISTRIB_RELEASE/dracut_install/*.deb
+	fi
 
 	if [ "$DISTRIB_TYPE" == "minimal" ]; then
 		warning_msg "Ignore install platform packages for minimal image."

--- a/config/boards/VIM3.inc
+++ b/config/boards/VIM3.inc
@@ -59,6 +59,14 @@ tweaks_platform() {
 ## Build deb packages for platform
 build_deb_packages_platform() {
 
+	if  [ "$DISTRIB_RELEASE" == "noble" ] ; then
+		info_msg "Building dracut_install package..."
+		# FIXME
+		# remove build stamp to force build for other arch
+		rm -rf $BUILD/.stamps/dracut_install
+		build_package "dracut_install:target"
+	fi
+
 	if [ "$DISTRIB_TYPE" == "minimal" ]; then
 		warning_msg "Ignore build platform packages for minimal image."
 		return 0
@@ -147,6 +155,11 @@ build_deb_packages_platform() {
 
 ## Install deb packages for platform
 install_deb_packages_platform() {
+
+	if [ "$DISTRIB_RELEASE" == "noble" ]; then
+		info_msg "Installing dracut_install package ..."
+		install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/$DISTRIBUTION-$DISTRIB_RELEASE/dracut_install/*.deb
+	fi
 
 	if [ "$DISTRIB_TYPE" == "minimal" ]; then
 		warning_msg "Ignore install platform packages for minimal image."

--- a/config/boards/VIM4.conf
+++ b/config/boards/VIM4.conf
@@ -233,6 +233,14 @@ tweaks_platform() {
 ## Build deb packages for platform
 build_deb_packages_platform() {
 
+	if  [ "$DISTRIB_RELEASE" == "noble" ] ; then
+		info_msg "Building dracut_install package..."
+		# FIXME
+		# remove build stamp to force build for other arch
+		rm -rf $BUILD/.stamps/dracut_install
+		build_package "dracut_install:target"
+	fi
+
 	if [ "$DISTRIB_TYPE" == "minimal" ]; then
 		warning_msg "Ignore build platform packages for minimal image."
 		return 0
@@ -332,6 +340,11 @@ build_deb_packages_platform() {
 
 ## Install deb packages for platform
 install_deb_packages_platform() {
+
+	if [ "$DISTRIB_RELEASE" == "noble" ]; then
+		info_msg "Installing dracut_install package ..."
+		install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/$DISTRIBUTION-$DISTRIB_RELEASE/dracut_install/*.deb
+	fi
 
 	if [ "$DISTRIB_TYPE" == "minimal" ]; then
 		warning_msg "Ignore install platform packages for minimal image."

--- a/config/functions/build-rootfs
+++ b/config/functions/build-rootfs
@@ -30,6 +30,9 @@ install_common()
 	# initial date for fake-hwclock
 	date -u '+%Y-%m-%d %H:%M:%S' > $ROOTFS_TEMP/etc/fake-hwclock.data
 
+	# temporarily disable initramfs generation
+	execute_in_chroot "chmod -v -x /etc/kernel/postinst.d/initramfs-tools"
+
 	# Install linux image deb in chroot
 	if [ -f $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${LINUX_IMAGE_DEB}_${VERSION}_${DISTRIB_ARCH}.deb ]; then
 		install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${LINUX_IMAGE_DEB}_${VERSION}_${DISTRIB_ARCH}.deb
@@ -93,6 +96,12 @@ install_common()
 		# Install updater deb in chroot
 		install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/${FENIX_UPDATER_DEB}_${VERSION}_${DISTRIB_ARCH}.deb
 	fi
+
+	# Now that all debs are installed, reenable initramfs-tools hook and generate initramfs
+	execute_in_chroot "chmod -v +x /etc/kernel/postinst.d/initramfs-tools"
+
+	kernel_version=$(ls $ROOTFS_TEMP/lib/modules)
+	execute_in_chroot "/usr/sbin/update-initramfs -u -k $kernel_version"
 
 	# Tweaks for platform
 	if [[ $(type -t tweaks_platform) == function ]]; then

--- a/packages/dracut_install/package.mk
+++ b/packages/dracut_install/package.mk
@@ -1,0 +1,24 @@
+PKG_NAME="dracut_install"
+PKG_VERSION="2a5ecdd24c6071fb71318eae20e4d97c0831fb37"
+PKG_SHA256="e8d5b24769de27dbd5cd0319b5266d98591472e808ae722380bff00e20afc999"
+PKG_SOURCE_DIR="dracut_install-${PKG_VERSION}*"
+PKG_SITE="$GITHUB_URL/numbqq/dracut_install"
+PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
+PKG_ARCH="aarch64"
+PKG_LICENSE="GPL"
+PKG_SHORTDESC="dracut_install"
+PKG_SOURCE_NAME="dracut_install-${PKG_VERSION}.tar.gz"
+PKG_NEED_BUILD="NO"
+
+
+make_target() {
+	:
+}
+
+makeinstall_target() {
+	mkdir -p $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/dracut_install
+	# Remove old debs
+	rm -rf $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/dracut_install/*
+	cp ${DISTRIB_RELEASE}/${DISTRIB_ARCH}/*.deb $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/dracut_install 2> /dev/null || \
+	cp -rf ${DISTRIB_RELEASE}/${DISTRIB_ARCH}/${KHADAS_BOARD}/${LINUX}/* $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/dracut_install
+}


### PR DESCRIPTION
This PR installs custom dracut install package that has [3de4c73](https://github.com/dracutdevs/dracut/commit/3de4c7313260fb600507c9b87f780390b874c870) and [131822e](https://github.com/dracutdevs/dracut/commit/131822e26d76a3ce2028e9a545be2af066805629) reverted.

Also we now only generate initrd once which also saves some time during the image build process.

PS: This PR depends on https://github.com/viraniac/dracut_install. It should be forked first before merging this PR.