### PR TITLE
Edge2: jammy: remove self built mutter and xwayland packages

### DIFF
--- a/config/boards/Edge2.conf
+++ b/config/boards/Edge2.conf
@@ -513,19 +513,7 @@ build_deb_packages_platform() {
 		rm -rf $BUILD/.stamps/rkaiq-rockchip-debs
 		build_package "rkaiq-rockchip-debs:target"
 
-		if [ "$DISTRIB_RELEASE" == "jammy" ] && [ "$DISTRIB_TYPE" == "gnome" ] && [ "$PANFORK_SUPPORT" != "yes" ]; then
-			info_msg "Building xwayland-deb ..."
-			# FIXME
-			# remove build stamp to force build for other arch
-			rm -rf $BUILD/.stamps/xwayland-deb
-			build_package "xwayland-deb:target"
-
-			info_msg "Building mutter-debs ..."
-			# FIXME
-			# remove build stamp to force build for other arch
-			rm -rf $BUILD/.stamps/mutter-debs
-			build_package "mutter-debs:target"
-		elif [ "$LINUX" == "noble" ] && [ "$DISTRIB_TYPE" != "server" ] && [ "$PANFORK_SUPPORT" != "yes" ]; then
+		if [ "$LINUX" == "noble" ] && [ "$DISTRIB_TYPE" != "server" ] && [ "$PANFORK_SUPPORT" != "yes" ]; then
 			info_msg "Building wayland-debs package..."
 			# FIXME
 			# remove build stamp to force build for other arch
@@ -590,18 +578,7 @@ install_deb_packages_platform() {
 		info_msg "Installing rkaiq..."
 		install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/rkaiq-rockchip-debs/*.deb
 
-		if [ "$DISTRIB_RELEASE" == "jammy" ] && [ "$DISTRIB_TYPE" == "gnome" ]; then
-			if [ "$PANFORK_SUPPORT" != "yes" ]; then
-				info_msg "Installing xwayland-deb packages ..."
-				install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/xwayland-deb/*.deb
-			fi
-
-			info_msg "Installing mutter-debs packages ..."
-			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/mutter-debs/mutter-common_*.deb
-			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/mutter-debs/mutter_*.deb
-			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/mutter-debs/libmutter-10-0_*.deb
-			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/mutter-debs/gir1.2-mutter-10_*.deb
-		elif [ "$LINUX" == "noble" ] && [ "$DISTRIB_TYPE" == "gnome" ]; then
+		if [ "$LINUX" == "noble" ] && [ "$DISTRIB_TYPE" == "gnome" ]; then
 			if [ "$PANFORK_SUPPORT" != "yes" ]; then
 				info_msg "Installing wayland-debs package ..."
 				install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/wayland-debs/libwayland-client0_*.deb


### PR DESCRIPTION
Upstream packages seems to work fine on current mali-debs package