### PR TITLE
fix make debs failure when building debs for Edge2

### DIFF
--- a/config/functions/build-board-deb
+++ b/config/functions/build-board-deb
@@ -341,11 +341,6 @@ build_board_deb() {
 		fi
 	fi
 
-	# Remove mali_csffw.bin if panfork is disabled
-	if [[ "$KHADAS_BOARD" == "Edge2" && "$PANFORK_SUPPORT" != "yes" ]]; then
-		rm $pkgdir/lib/firmware/mali_csffw.bin
-	fi
-
 	# Copy Wi-Fi & BT firmware
 	if [ "$WIFI_MODEL" == "Broadcom" ]; then
 		# Copy Wi-Fi firmware


### PR DESCRIPTION
As I understood from Jacobe, this is no longer required and needs to be removed.