### PR TITLE
Noble: remove pulseaudio to fix browser video playback issue

### DIFF
--- a/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-dmic.lua
+++ b/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-dmic.lua
@@ -1,0 +1,13 @@
+rule = {
+    matches = {
+        {
+            { "device.bus-path", "equals", "platform-sound-micarray" },
+        },
+    },
+    apply_properties = {
+        ["device.description"] = "DMIC",
+        ["node.description"] = "DMIC",
+    },
+}
+
+table.insert(alsa_monitor.rules,rule)

--- a/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-dp.lua
+++ b/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-dp.lua
@@ -1,0 +1,13 @@
+rule = {
+    matches = {
+        {
+            { "device.bus-path", "equals", "platform-dp0-sound" },
+        },
+    },
+    apply_properties = {
+        ["device.description"] = "DP",
+        ["node.description"] = "DP",
+    },
+}
+
+table.insert(alsa_monitor.rules,rule)

--- a/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-es8316.lua
+++ b/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-es8316.lua
@@ -1,0 +1,13 @@
+rule = {
+    matches = {
+        {
+            { "device.bus-path", "equals", "platform-es8316-sound" },
+        },
+    },
+    apply_properties = {
+        ["device.description"] = "ES8316 Codec",
+        ["node.description"] = "ES8316 Codec",
+    },
+}
+
+table.insert(alsa_monitor.rules,rule)

--- a/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-hdmi.lua
+++ b/archives/filesystem/special/Edge2/etc/wireplumber/main.lua.d/51-hdmi.lua
@@ -1,0 +1,13 @@
+rule = {
+    matches = {
+        {
+            { "device.bus-path", "equals", "platform-hdmi0-sound" },
+        },
+    },
+    apply_properties = {
+        ["device.description"] = "HDMI",
+        ["node.description"] = "HDMI",
+    },
+}
+
+table.insert(alsa_monitor.rules,rule)

--- a/config/config
+++ b/config/config
@@ -388,7 +388,7 @@ case $DISTRIB_RELEASE in
 	noble)
 		DEBOOTSTRAP_COMPONENTS="main,universe"
 		[[ "$DISTRIB_TYPE" != "minimal" ]] && PACKAGE_LIST_RELEASE="man-db kbd gnupg2 dirmngr networkd-dispatcher libjpeg9 command-not-found libgrpc++1.51t64 libboost-system1.83.0 libgcc1 rng-tools iozone3"
-		PACKAGE_LIST_DESKTOP+=" $PACKAGE_LIST_GSTREAMER xserver-xorg-input-all pulseaudio pulseaudio-module-bluetooth pulseaudio-module-gsettings language-selector-gnome viewnior dbus-user-session libreoffice-style-tango"
+		PACKAGE_LIST_DESKTOP+=" $PACKAGE_LIST_GSTREAMER xserver-xorg-input-all language-selector-gnome viewnior dbus-user-session libreoffice-style-tango"
 		PACKAGE_LIST_OFFICE+="paprefs"
 	;;
 esac


### PR DESCRIPTION
Switched to pipewire instead of pulseaudio. Fixes video playback issue in the browser. 

Tested with 5.10 Noble image with sound playback on HDMI Audio and also on samsung galaxy buds bluetooth audio