### PR TITLE
Fixes for xfce image for vim1s

### DIFF
--- a/config/boards/VIM1S.conf
+++ b/config/boards/VIM1S.conf
@@ -344,7 +344,7 @@ install_deb_packages_platform() {
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/chromium-debs/chromium_*.deb
 		fi
 
-		if ([ "$DISTRIB_RELEASE" == "noble" ] || [ "$DISTRIB_RELEASE" == "jammy" ] && [ "$Ubuntu_TYPE" != "xfce" ] || [ "$DISTRIB_RELEASE" == "bookworm" ]) && [ "$DISTRIB_TYPE" != "server" ]; then
+		if ([ "$DISTRIB_RELEASE" == "noble" ] || [ "$DISTRIB_RELEASE" == "jammy" ] || [ "$DISTRIB_RELEASE" == "bookworm" ]) && [ "$DISTRIB_TYPE" != "server" ] && [ "$DISTRIB_TYPE" != "xfce" ] ; then
 			info_msg "Installing mali-debs package ..."
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/$DISTRIBUTION-$DISTRIB_RELEASE/mali-debs/${GPU_PLATFORM}/*.deb
 		fi

--- a/config/config
+++ b/config/config
@@ -312,7 +312,7 @@ case $DISTRIB_TYPE in
 	xfce)
 		PACKAGE_LIST_DESKTOP+=" $PACKAGE_LIST_OFFICE"
 		PACKAGE_LIST_DESKTOP+=" lightdm lightdm-gtk-greeter xfce4 lxtask xfce4-screenshooter xfce4-notifyd xfce4-terminal desktop-base software-properties-gtk thunar-archive-plugin xfce4-power-manager"
-		[[ $DISTRIBUTION == Ubuntu ]] && PACKAGE_LIST_DESKTOP+=" update-manager"
+		[[ $DISTRIBUTION == Ubuntu ]] && PACKAGE_LIST_DESKTOP+=" update-manager x11-utils"
 	;;
 	lxde)
 		PACKAGE_LIST_DESKTOP+=" $PACKAGE_LIST_OFFICE"


### PR DESCRIPTION
As chromium needs x11-utils, the creation of xfce image was broken. Also linux-gpu-mali-wayland package was getting installed which was causing the X server to fail, fixed the same as well.