### PR TITLE
Minor fixes

### DIFF
--- a/archives/filesystem/special/VIM-COMMON/etc/modules-load.d/microk8s.conf
+++ b/archives/filesystem/special/VIM-COMMON/etc/modules-load.d/microk8s.conf
@@ -18,3 +18,4 @@ ip6table_mangle
 ip6table_filter
 nf_reject_ipv6
 ip6t_REJECT
+xt_multiport

--- a/archives/filesystem/special/VIM-COMMON/usr/local/bin/hdmitx_hpd_event.sh
+++ b/archives/filesystem/special/VIM-COMMON/usr/local/bin/hdmitx_hpd_event.sh
@@ -9,7 +9,7 @@ if systemctl is-enabled resize2fs.service | grep "^enabled$" > /dev/null; then
 	exit
 fi
 
-if [ ! -d /usr/share/desktop-base ]; then
+if ! systemctl is-active --quiet gdm ; then
 	## For server
 	## Get hdmi resolution
 	for x in $(cat /proc/cmdline); do

--- a/config/config
+++ b/config/config
@@ -324,6 +324,7 @@ case $DISTRIB_TYPE in
 		PACKAGE_LIST_DESKTOP+=" desktop-base software-properties-gtk gnome-terminal gnome-shell-extensions gnome-tweaks gnome-screenshot"
 		([[ $DISTRIB_RELEASE == focal ]] || [[ $DISTRIB_RELEASE == jammy ]] || [[ $DISTRIB_RELEASE == noble ]]) && PACKAGE_LIST_DESKTOP+=" yaru-theme-gtk yaru-theme-icon yaru-theme-sound"
 		[[ $DISTRIBUTION == Ubuntu ]] && PACKAGE_LIST_DESKTOP+=" ubuntu-desktop update-manager"
+		[[ $DISTRIB_RELEASE == noble ]] && PACKAGE_LIST_DESKTOP+=" gnome-remote-desktop"
 	;;
 esac
 


### PR DESCRIPTION
- Only restart gdm3 if its already running, fixes gdm3 restart on hdmi hotpug when default target is set to multi-user.target on gnome image.
- Added gnome-remote-desktop for gnome noble image. It was installed on jammy but not on noble. Noble was having a blank settings panel because of the same.
- Added xt_multiport to list of modules required for microk8s