### PR TITLE
Fix missing capabilities resulting into ping not working for unprivileged users

### DIFF
--- a/config/functions/build-rootfs
+++ b/config/functions/build-rootfs
@@ -259,7 +259,7 @@ create_rootfs_cache()
 		if [[ $cache_sha256 == $calc_sha256 ]]; then
 			info_msg "Extracting $display_name $date_diff days old"
 			# may be no need progress at all its very fast
-			lz4 -dc < $cache_fname | tar xp --xattrs -C $ROOTFS_TEMP/
+			lz4 -dc < $cache_fname | tar xp --xattrs-include='*' -C $ROOTFS_TEMP/
 			qemu_helper "$ROOTFS_TEMP"
 			return
 		else


### PR DESCRIPTION
GNU Tar only seems to restore extended attributes that matches `user.*` pattern by default when --xattr pattern is used. Lets specifying that we want all extended attributes to be restored.

This fixes ping requiring sudo privileges. Now ping, arping, fping, etc in the image are keeping their cap_net_raw=ep capabilities as expected.