### PR TITLE
Edge2: install custom gstreamer packages

### DIFF
--- a/config/boards/Edge2.conf
+++ b/config/boards/Edge2.conf
@@ -546,7 +546,7 @@ install_deb_packages_platform() {
 
 		# Install mpp in chroot
 		info_msg "Installing mpp..."
-		if [ "$DISTRIB_RELEASE" == "jammy" ]; then
+		if [ "$DISTRIB_RELEASE" == "jammy" ] || [ "$DISTRIB_RELEASE" == "bookworm" ]; then
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/mpp-rockchip-debs/rockchip-mpp_*.deb
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/mpp-rockchip-debs/rockchip-mpp-sample_*.deb
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/mpp-rockchip-debs/rockchip-mpp-dev_*.deb
@@ -559,7 +559,7 @@ install_deb_packages_platform() {
 
 		# Install rga in chroot
 		info_msg "Installing rga..."
-		if [ "$DISTRIB_RELEASE" == "jammy" ]; then
+		if [ "$DISTRIB_RELEASE" == "jammy" ] || [ "$DISTRIB_RELEASE" == "bookworm" ]; then
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/rga-rockchip-debs/rockchip-rga_*.deb
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/rga-rockchip-debs/rockchip-rga-sample_*.deb
 			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/rga-rockchip-debs/rockchip-rga-dev_*.deb
@@ -572,6 +572,30 @@ install_deb_packages_platform() {
 		# Install gstreamer in chroot
 		info_msg "Installing gstreamer..."
 		install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/*.deb
+		if [ "$DISTRIB_RELEASE" == "noble" ] || [ "$DISTRIB_RELEASE" == "jammy" ] || [ "$DISTRIB_RELEASE" == "bookworm" ]; then
+			# gstreamer1.0
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gstreamer1.0-debs/libgstreamer1.0-0_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gstreamer1.0-debs/gir1.2-gstreamer-1.0_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gstreamer1.0-debs/gstreamer1.0-tools_*.deb
+
+			# gst-plugins-base1.0
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-base1.0-debs/libgstreamer-plugins-base1.0-0_*.deb
+			#install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-base1.0-debs/libgstreamer-gl1.0-0_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-base1.0-debs/gstreamer1.0-plugins-base_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-base1.0-debs/gstreamer1.0-plugins-base-apps_*.deb
+			#install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-base1.0-debs/gstreamer1.0-x_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-base1.0-debs/gstreamer1.0-alsa_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-base1.0-debs/gir1.2-gst-plugins-base-1.0_*.deb
+
+			# gst-plugins-good1.0
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-good1.0-debs/libgstreamer-plugins-good1.0-0_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-good1.0-debs/gstreamer1.0-plugins-good_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-good1.0-debs/gstreamer1.0-pulseaudio_*.deb
+
+			# gst-plugins-bad1.0
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-bad1.0-debs/libgstreamer-plugins-bad1.0-0_*.deb
+			install_deb_chroot $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/gst-plugins-bad1.0-debs/gstreamer1.0-plugins-bad_*.deb
+		fi
 
 		# Install rkaiq in chroot
 		info_msg "Installing rkaiq..."

--- a/packages/gstreamer-rockchip-debs/package.mk
+++ b/packages/gstreamer-rockchip-debs/package.mk
@@ -1,6 +1,6 @@
 PKG_NAME="gstreamer-rockchip-debs"
-PKG_VERSION="5a09ea919db53609809108a6b8d1c1388e273f39"
-PKG_SHA256="174dae0db1c7745314be038f0acd355d5fa882d4e06f3856127f084e49026ab9"
+PKG_VERSION="0b71624e0ba56bbdc2b16c35ee3117cad575635e"
+PKG_SHA256="853cdfdb7379a046bb664e0e5bb0fbfb53ef6a071cba6ddc74bec18d6c418c78"
 PKG_SOURCE_DIR="gstreamer-rockchip-debs-${PKG_VERSION}*"
 PKG_SITE="$GITHUB_URL/numbqq/gstreamer-rockchip-debs"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
@@ -18,6 +18,6 @@ makeinstall_target() {
 	mkdir -p $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs
 	# Remove old debs
 	rm -rf $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs/*
-	[ -d ${DISTRIB_RELEASE}/${DISTRIB_ARCH}/${KHADAS_BOARD} ] && cp -r ${DISTRIB_RELEASE}/${DISTRIB_ARCH}/${KHADAS_BOARD}/* $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs || true
+	[ -d ${DISTRIB_RELEASE}/${DISTRIB_ARCH}/${KHADAS_BOARD} ] && cp -rL ${DISTRIB_RELEASE}/${DISTRIB_ARCH}/${KHADAS_BOARD}/* $BUILD_DEBS/$VERSION/$KHADAS_BOARD/${DISTRIBUTION}-${DISTRIB_RELEASE}/gstreamer-rockchip-debs || true
 }
 


### PR DESCRIPTION
Encoding and decoding works on both 5.10 and 6.1 kernel on Noble. For jammy and bookworm, as older version of rga and mpp package is installed, mppvideodec and mpph264enc only works with 5.10 kernel.

Tested on jammy, bookworm and noble server images using following pipeline
```
$ gst-launch-1.0 filesrc location=~/Downloads/Big_Buck_Bunny_1080_10s_30MB.mp4 ! qtdemux name=d d.video_0 ! h264parse ! mppvideodec ! video/x-raw,format=NV12 ! mpph264enc ! h264parse ! mppvideodec ! video/x-raw,format=NV12 ! kmssink plane-id=101
```

Tested on Noble gnome image using following pipeline
```
$ gst-launch-1.0 filesrc location=~/Downloads/Big_Buck_Bunny_1080_10s_30MB.mp4 ! qtdemux name=d d.video_0 ! h264parse ! mppvideodec ! video/x-raw,format=NV12 ! mpph264enc ! h264parse ! mppvideodec ! video/x-raw,format=NV12 ! waylandsink
```

