### PR TITLE
Fix: debian xfce images gets both gnome and xfce installed

### DIFF
--- a/config/config
+++ b/config/config
@@ -324,6 +324,7 @@ case $DISTRIB_TYPE in
 		PACKAGE_LIST_DESKTOP+=" desktop-base software-properties-gtk gnome-terminal gnome-shell-extensions gnome-tweaks gnome-screenshot"
 		([[ $DISTRIB_RELEASE == focal ]] || [[ $DISTRIB_RELEASE == jammy ]] || [[ $DISTRIB_RELEASE == noble ]]) && PACKAGE_LIST_DESKTOP+=" yaru-theme-gtk yaru-theme-icon yaru-theme-sound"
 		[[ $DISTRIBUTION == Ubuntu ]] && PACKAGE_LIST_DESKTOP+=" ubuntu-desktop update-manager"
+		[[ $DISTRIBUTION == Debian ]] && PACKAGE_LIST_DESKTOP+=" task-gnome-desktop"
 		[[ $DISTRIB_RELEASE == noble ]] && PACKAGE_LIST_DESKTOP+=" gnome-remote-desktop"
 	;;
 esac
@@ -346,7 +347,7 @@ case $DISTRIB_RELEASE in
 		PACKAGE_LIST_QT+=" libqt5multimediaquick5"
 		PACKAGE_LIST_MESA="libglvnd-dev libx11-dev"
 		PACKAGE_LIST_DESKTOP+=" $PACKAGE_LIST_GSTREAMER $PACKAGE_LIST_KODI $PACKAGE_LIST_MESA"
-		PACKAGE_LIST_DESKTOP+=" numix-icon-theme chromium mirage task-gnome-desktop dbus-user-session"
+		PACKAGE_LIST_DESKTOP+=" numix-icon-theme chromium mirage dbus-user-session"
 	;;
 	focal|hirsute)
 		DEBOOTSTRAP_COMPONENTS="main,universe"


### PR DESCRIPTION
When creating debian bookworm xfce image for VIM1S, I noticed the image still booted into gnome instead of xfce and it had both xfce and gnome installed on it. This fixes the same.