### PR TITLE
VIM3/3L: bump mainline to 6.11.2

### DIFF
--- a/config/boards/VIM3.conf
+++ b/config/boards/VIM3.conf
@@ -54,7 +54,7 @@ esac
 case "$LINUX" in
 	mainline)
 		LINUX_DTB="$LINUX_DIR/arch/arm64/boot/dts/amlogic/meson-g12b-a311d-khadas-vim3.dtb"
-		LINUX_GIT_BRANCH="khadas-linux-6.9.y"
+		LINUX_GIT_BRANCH="khadas-linux-6.11.y"
 		LINUX_DEFCONFIG="${LINUX_DEFCONFIG:-kvims_defconfig}"
 		SERIALCON="ttyAML0"
 		GPU_VER=""

--- a/config/boards/VIM3L.conf
+++ b/config/boards/VIM3L.conf
@@ -54,7 +54,7 @@ esac
 case "$LINUX" in
 	mainline)
 		LINUX_DTB="$LINUX_DIR/arch/arm64/boot/dts/amlogic/meson-sm1-khadas-vim3l.dtb"
-		LINUX_GIT_BRANCH="khadas-linux-6.9.y"
+		LINUX_GIT_BRANCH="khadas-linux-6.11.y"
 		LINUX_DEFCONFIG="${LINUX_DEFCONFIG:-kvims_defconfig}"
 		SERIALCON="ttyAML0"
 		GPU_VER=""


### PR DESCRIPTION
Depends on https://github.com/viraniac/khadas_linux/tree/khadas-linux-6.11.y