### PR TITLE
Fix building on docker desktop for windows with WSL2 backend

### DIFF
--- a/config/functions/build-rootfs
+++ b/config/functions/build-rootfs
@@ -530,7 +530,7 @@ prepare_partitions()
 		fi
 
 		export IMAGE_LOOP_DEV
-		IMAGE_LOOP_DEV="$(losetup --show -f ${BUILD_IMAGES}/${IMAGE_FILE_NAME})"
+		IMAGE_LOOP_DEV="$(losetup -P --show -f ${BUILD_IMAGES}/${IMAGE_FILE_NAME})"
 		info_msg "Allocated loop device: $IMAGE_LOOP_DEV"
 		if [[ -z $IMAGE_LOOP_DEV ]]; then
 			error_msg "Unable to find free loop device!"


### PR DESCRIPTION
Fix image build issue when building on docker desktop on Windows with WSL backend, partprobe fails with the following error

`
Error: Partition(s) 1, 2 on /dev/loop2 have been written, but we have been unable to inform the kernel of the change, probably because it/they are in use.  As a result, the old partition(s) will remain in use.  You should reboot now before making further changes.
`

Tested with docker desktop on Windows as well as docker desktop on MacOS using following command to create fenix container instance

```
$ docker run -it --name fenix --privileged \
             --device=/dev/loop-control:/dev/loop-control \
             --device=/dev/loop0:/dev/loop0 --cap-add SYS_ADMIN \
             numbqq/fenix
```