### PR TITLE
Load panfrost/panthor-gpu overlay when building with PANFROST_SUPPORT

### DIFF
--- a/config/boards/Edge2.conf
+++ b/config/boards/Edge2.conf
@@ -465,6 +465,11 @@ customize_platform() {
 		eval 'LC_ALL=C LANG=C chroot $ROOTFS_TEMP /bin/bash -c "DEBIAN_FRONTEND=noninteractive apt-get -y $apt_extra install libegl-mesa0 libgbm1 libglapi-mesa libglx-mesa0"'
 
 		umount_chroot "$ROOTFS_TEMP"
+
+		if [ "$LINUX" != "mainline" ]; then
+			local overlay_env="$ROOTFS_TEMP/boot/dtb/${VENDOR,,}/$(basename $LINUX_DTB).overlay.env"
+			sed -i --follow-symlinks '/fdt_overlays/s/=/=panthor-gpu /g' $overlay_env
+		fi
 	fi
 }
 

--- a/config/boards/VIM1S.conf
+++ b/config/boards/VIM1S.conf
@@ -228,6 +228,11 @@ tweaks_platform() {
 		# Setup default DTB for SD/USB images
 		execute_in_chroot "ln -fs dtb/amlogic/$(basename $LINUX_DTB) /boot/dtb.img"
 	fi
+
+	if [ "$LINUX" != "mainline" ] && [ "$PANFROST_SUPPORT" == "yes" ]; then
+		local overlay_env="$ROOTFS_TEMP/boot/dtb/${VENDOR,,}/$(basename $LINUX_DTB).overlay.env"
+		sed -i --follow-symlinks '/fdt_overlays/s/=/=panfrost /g' $overlay_env
+	fi
 }
 
 ## Build deb packages for platform

--- a/config/boards/VIM3.inc
+++ b/config/boards/VIM3.inc
@@ -54,6 +54,11 @@ tweaks_platform() {
 			execute_in_chroot "cp /boot/dtb/$(basename $LINUX_DTB) /boot/dtb.img"
 		fi
 	fi
+
+	if [ "$LINUX" != "mainline" ] && [ "$PANFROST_SUPPORT" == "yes" ]; then
+		local overlay_env="$ROOTFS_TEMP/boot/dtb/${VENDOR,,}/$(basename $LINUX_DTB).overlay.env"
+		sed -i --follow-symlinks '/fdt_overlays/s/=/=panfrost /g' $overlay_env
+	fi
 }
 
 ## Build deb packages for platform

--- a/config/boards/VIM4.conf
+++ b/config/boards/VIM4.conf
@@ -228,6 +228,11 @@ tweaks_platform() {
 		# Setup default DTB for SD/USB images
 		execute_in_chroot "ln -fs dtb/amlogic/$(basename $LINUX_DTB) /boot/dtb.img"
 	fi
+
+	if [ "$LINUX" != "mainline" ] && [ "$PANFROST_SUPPORT" == "yes" ]; then
+		local overlay_env="$ROOTFS_TEMP/boot/dtb/${VENDOR,,}/$(basename $LINUX_DTB).overlay.env"
+		sed -i --follow-symlinks '/fdt_overlays/s/=/=panfrost /g' $overlay_env
+	fi
 }
 
 ## Build deb packages for platform


### PR DESCRIPTION
The panfrost/panthor support is disabled by default in dtb and dt overlays are needed to be applied during boot to use the same. Make sure they get listed in the overlay.env file when building images with panfrost support