### PR TITLE
Generalize handling of display managers on hpd event

### DIFF
--- a/archives/filesystem/special/VIM-COMMON/usr/local/bin/hdmitx_hpd_event.sh
+++ b/archives/filesystem/special/VIM-COMMON/usr/local/bin/hdmitx_hpd_event.sh
@@ -9,7 +9,7 @@ if systemctl is-enabled resize2fs.service | grep "^enabled$" > /dev/null; then
 	exit
 fi
 
-if ! (systemctl is-active --quiet gdm || systemctl is-active --quiet lightdm); then
+if ! (systemctl is-active --quiet display-manager.service); then
 	## For server
 	## Get hdmi resolution
 	for x in $(cat /proc/cmdline); do
@@ -33,19 +33,7 @@ else
 	## For desktop
 	## Restart the display manager (gdm3 or lightdm) when hdmitx plugin
 
-	gdm_process_name="gdm-wayland-session"
-	lightdm_process_name="lightdm"
-	gdm_search_string="/usr/libexec/gdm-wayland-session"
-	lightdm_search_string="/usr/sbin/lightdm"
-
-	gdm_output=$(ps aux | grep "$gdm_process_name" | grep -v "grep")
-	lightdm_output=$(ps aux | grep "$lightdm_process_name" | grep -v "grep")
-
-	if [ "$gdm_output" ]; then
-		systemctl restart gdm3
-	elif [ "$lightdm_output" ]; then
-		systemctl restart lightdm
-	fi
+	systemctl reload-or-restart display-manager.service
 fi
 
 exit


### PR DESCRIPTION
Generalize handling of display managers on hpd event for vim boards. Now if display-manager supports reload action, then the same is used otherwise they will get restarted on hotplug. As gdm supports reloading the service, this fixes application getting killed after sleep issue on Gnome image for vim boards. The xfce image for vim1s however will still have the same issue as lightdm still gets restarted on HDMI hotplug.