### PR TITLE
Usb c pd negotiation  

### DIFF
--- a/packages/u-boot-mainline/patches/0719bf42931033c3109ecc6357e8adb567cb637b/0038-add-FUSB302-support.patch
+++ b/packages/u-boot-mainline/patches/0719bf42931033c3109ecc6357e8adb567cb637b/0038-add-FUSB302-support.patch
@@ -687,12 +687,12 @@ index 00000000..8b2b75ed
 +			switch (CAP_POWER_TYPE(chip->rec_load[chip->pos_power - 1])) {
 +			case 0:
 +				/* Fixed Supply */
-+				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_FPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			case 1:
 +				/* Battery */
-+				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_VPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			default:

--- a/packages/u-boot-mainline/patches/caad316b3165615f1a4848901811a4a084444c9d/0046-add-FUSB302-support.patch
+++ b/packages/u-boot-mainline/patches/caad316b3165615f1a4848901811a4a084444c9d/0046-add-FUSB302-support.patch
@@ -687,12 +687,12 @@ index 00000000..8b2b75ed
 +			switch (CAP_POWER_TYPE(chip->rec_load[chip->pos_power - 1])) {
 +			case 0:
 +				/* Fixed Supply */
-+				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_FPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			case 1:
 +				/* Battery */
-+				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_VPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			default:

--- a/packages/u-boot-mainline/patches/v2021.01/0038-add-FUSB302-support.patch
+++ b/packages/u-boot-mainline/patches/v2021.01/0038-add-FUSB302-support.patch
@@ -678,7 +678,7 @@ index 00000000..8b2b75ed
 +				break;
 +			case 1:
 +				/* Battery */
-+				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_VPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			default:

--- a/packages/u-boot-mainline/patches/v2021.01/0038-add-FUSB302-support.patch
+++ b/packages/u-boot-mainline/patches/v2021.01/0038-add-FUSB302-support.patch
@@ -673,7 +673,7 @@ index 00000000..8b2b75ed
 +			switch (CAP_POWER_TYPE(chip->rec_load[chip->pos_power - 1])) {
 +			case 0:
 +				/* Fixed Supply */
-+				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_FPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			case 1:

--- a/packages/u-boot-mainline/patches/v2021.04/0031-add-FUSB302-support.patch
+++ b/packages/u-boot-mainline/patches/v2021.04/0031-add-FUSB302-support.patch
@@ -673,12 +673,12 @@ index 0000000000..ac5b3439e4
 +			switch (CAP_POWER_TYPE(chip->rec_load[chip->pos_power - 1])) {
 +			case 0:
 +				/* Fixed Supply */
-+				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_FPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			case 1:
 +				/* Battery */
-+				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_VPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			default:

--- a/packages/u-boot-mainline/patches/v2024.10/0028-add-FUSB302-support.patch
+++ b/packages/u-boot-mainline/patches/v2024.10/0028-add-FUSB302-support.patch
@@ -672,12 +672,12 @@ index 0000000000..ac5b3439e4
 +			switch (CAP_POWER_TYPE(chip->rec_load[chip->pos_power - 1])) {
 +			case 0:
 +				/* Fixed Supply */
-+				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_FPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_FPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			case 1:
 +				/* Battery */
-+				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10) & 0x3ff);
++				chip->send_load[0] |= ((CAP_VPDO_VOLTAGE(chip->rec_load[chip->pos_power - 1]) << 10));
 +				chip->send_load[0] |= (CAP_VPDO_CURRENT(chip->rec_load[chip->pos_power - 1]) & 0x3ff);
 +				break;
 +			default:


### PR DESCRIPTION
he Voltage/Current select was incorrect in the sent PD message.  The data was being & with 0x3ff which removed the voltage values. Removed the AND function.

Tested with Many different PD power supplies.
             Correct Voltage selected
             Current limit enfored by PD controllers. ( The current selected is what it really gets!) 