### PR TITLE
packages: rkbin: bump to 9ab19cc4

### DIFF
--- a/packages/rkbin/package.mk
+++ b/packages/rkbin/package.mk
@@ -1,6 +1,6 @@
 PKG_NAME="rkbin"
-PKG_VERSION="2c1be1054e86338285309ecc20fa61fc15fd5437"
-PKG_SHA256="9394e57f508e92bdeb1faa00a96957e31d0f23f705584d507253fc49f38524f1"
+PKG_VERSION="9ab19cc4adfad92d415e0660ae95c60eac45c2eb"
+PKG_SHA256="47005e3a87ceba3a9825b7d44590f349b90f5501f889f0f4c0f050b517574dfb"
 PKG_SOURCE_DIR="rkbin-${PKG_VERSION}*"
 PKG_SITE="$GITHUB_URL/numbqq/rkbin"
 PKG_URL="$PKG_SITE/archive/$PKG_VERSION.tar.gz"
@@ -14,9 +14,9 @@ PKG_NEED_BUILD="NO"
 make_host() {
 	# Fixup links
 	# For Edge2
-	ln -fs bin/rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.18.bin rk3588_ddr.bin
-	ln -fs bin/rk35/rk3588_bl31_v1.48.elf rk3588_bl31.elf
-	ln -fs bin/rk35/rk3588_bl32_v1.19.bin rk3588_bl32.bin
+	ln -fs bin/rk35/rk3588_ddr_lp4_2112MHz_lp5_2400MHz_v1.20.bin rk3588_ddr.bin
+	ln -fs bin/rk35/rk3588_bl31_v1.53.elf rk3588_bl31.elf
+	ln -fs bin/rk35/rk3588_bl32_v1.20.bin rk3588_bl32.bin
 	ln -fs bin/rk35/rk3588_spl_v1.13.bin rk3588_spl.bin
 }
 


### PR DESCRIPTION
Merge master fork

commit 9ab19cc4adfad92d415e0660ae95c60eac45c2eb
Author: Weiwen Chen <cww@rock-chips.com>
Date:   Wed Aug 27 14:25:44 2025 +0800

    RKBOOT: Add RV1126BPMINIALL_FASTBOOT.ini

    Signed-off-by: Weiwen Chen <cww@rock-chips.com>
    Change-Id: I18ccffcef9e1b7002d32eb53b3fba68f673e653b